### PR TITLE
Do not change response code after 204

### DIFF
--- a/writerwrapper.go
+++ b/writerwrapper.go
@@ -118,6 +118,7 @@ func (w *writerWrapper) Write(data []byte) (int, error) {
 	}
 
 	if !w.shouldCompress {
+		w.WriteHeaderNow()
 		return w.OriginWriter.Write(data)
 	}
 	if w.bodyBigEnough {

--- a/writerwrapper_test.go
+++ b/writerwrapper_test.go
@@ -389,3 +389,12 @@ func Test_writerWrapper_Write_content_type_no_sniff(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, bigPayload, body)
 }
+
+func Test_writeWrapper_does_not_change_status_code_after_204(t *testing.T) {
+	wrapper, recorder := newWrapper()
+
+	wrapper.WriteHeader(http.StatusNoContent)
+	_, _ = wrapper.Write([]byte("something"))
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+}


### PR DESCRIPTION
There's a bug in the `writerwrapper`. If you call `WriteHeader` with either 204 or 304, `shouldCompress` would be set to false and then all subsequent calls to `Write` will result in directly calling the `OriginWriter.Write` but since the status code is not written to `OriginWriter`, it will set it to 200. Another side effect of this is that `Write` will not only set the status code to 200 but it will also write the content of `data` to `Body` which would not normally happen if the gzip middleware is not used. Instead, if you set the status code to 204 or 304, any calls to `Write` will fail with an error. The correct unit test for this would be:
```
func Test_writeWrapper_does_not_change_status_code_after_204(t *testing.T) {
	wrapper, recorder := newWrapper()

	wrapper.WriteHeader(http.StatusNoContent)
	n, err := wrapper.Write([]byte("something"))

	assert.Equal(t, 0, n)
	assert.Error(t, err)
	assert.Equal(t, http.StatusNoContent, recorder.Code)
	assert.Equal(t, []byte{}, recorder.Body.Bytes())
}
```

The problem is that `recorder` actually behaves differently from `server.response` and won't check for 204, 304 (the actual call that `server.response` makes is `bodyAllowedForStatus(w.status)`) so `recorder` will both manage to record the 204 status code and the body (which won't happen in reality). Yet, I didn't find a way to instantiate the actual `server.response` and test against it. So, in the unit tests, the body will be written but in actual use cases, an error will be thrown as expected.